### PR TITLE
In August 31, 2017 Vanvite turned off current production URLs

### DIFF
--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -18,14 +18,14 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
      *
      * @var string URL
      */
-    protected $preLiveEndpoint = 'https://transact-prelive.litle.com/vap/communicator/online';
+    protected $preLiveEndpoint = 'https://transact.vantivprelive.com/vap/communicator/online';
 
     /**
      * Live Endpoint URL
      *
      * @var string URL
      */
-    protected $liveEndpoint = 'https://transact.litle.com/vap/communicator/online';
+    protected $liveEndpoint = 'https://transact.vantivcnp.com/vap/communicator/online';
 
     public function getMerchantId()
     {

--- a/tests/Message/AuthorizeRequestTest.php
+++ b/tests/Message/AuthorizeRequestTest.php
@@ -68,7 +68,7 @@ class AuthorizeRequestTest extends TestCase
     public function testGetPreliveEndpoint()
     {
         $this->assertSame($this->request, $this->request->setPreLiveMode(true));
-        $this->assertSame('https://transact-prelive.litle.com/vap/communicator/online', $this->request->getEndpoint());
+        $this->assertSame('https://transact.vantivprelive.com/vap/communicator/online', $this->request->getEndpoint());
     }
 
     public function testTestEndpoint()
@@ -81,12 +81,12 @@ class AuthorizeRequestTest extends TestCase
     {
         $this->assertSame($this->request, $this->request->setPreLiveMode(true));
         $this->assertSame($this->request, $this->request->setTestMode(true));
-        $this->assertSame('https://transact-prelive.litle.com/vap/communicator/online', $this->request->getEndpoint());
+        $this->assertSame('https://transact.vantivprelive.com/vap/communicator/online', $this->request->getEndpoint());
     }
 
     public function testLiveEndpoint()
     {
-        $this->assertSame('https://transact.litle.com/vap/communicator/online', $this->request->getEndpoint());
+        $this->assertSame('https://transact.vantivcnp.com/vap/communicator/online', $this->request->getEndpoint());
     }
 
     /**

--- a/tests/Message/PurchaseRequestTest.php
+++ b/tests/Message/PurchaseRequestTest.php
@@ -68,7 +68,7 @@ class PurchaseRequestTest extends TestCase
     public function testGetPreliveEndpoint()
     {
         $this->assertSame($this->request, $this->request->setPreLiveMode(true));
-        $this->assertSame('https://transact-prelive.litle.com/vap/communicator/online', $this->request->getEndpoint());
+        $this->assertSame('https://transact.vantivprelive.com/vap/communicator/online', $this->request->getEndpoint());
     }
 
     public function testTestEndpoint()
@@ -81,7 +81,7 @@ class PurchaseRequestTest extends TestCase
     {
         $this->assertSame($this->request, $this->request->setPreLiveMode(true));
         $this->assertSame($this->request, $this->request->setTestMode(true));
-        $this->assertSame('https://transact-prelive.litle.com/vap/communicator/online', $this->request->getEndpoint());
+        $this->assertSame('https://transact.vantivprelive.com/vap/communicator/online', $this->request->getEndpoint());
     }
 
     /**


### PR DESCRIPTION
https://www.vantiv.com/content/dam/vantiv/merchants-partners/docs/ecommerce-domains-faq-june-2017.pdf